### PR TITLE
3 add qpixmap example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ qmake.*
 *.vcxproj*
 moc_*.cpp
 qrc_*.cpp
+moc_*.h
+qrc_*.h
+*.cbt
 .vs/
 x86_64/

--- a/Qt/qpixmapexample/CMakeLists.txt
+++ b/Qt/qpixmapexample/CMakeLists.txt
@@ -1,0 +1,86 @@
+cmake_minimum_required(VERSION 3.5)
+
+# set project name
+set( APP_NAME_qpixmapexample maplinkqpixmapexample )
+project(${APP_NAME_qpixmapexample} LANGUAGES CXX)
+
+# set parameters
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# QtCreator supports the following variables for Android, which are identical to qmake Android variables.
+# Check http://doc.qt.io/qt-5/deployment-android.html for more information.
+# They need to be set before the find_package(Qt5 ...) call.
+
+#if(ANDROID)
+#    set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
+#    if (ANDROID_ABI STREQUAL "armeabi-v7a")
+#        set(ANDROID_EXTRA_LIBS
+#            ${CMAKE_CURRENT_SOURCE_DIR}/path/to/libcrypto.so
+#            ${CMAKE_CURRENT_SOURCE_DIR}/path/to/libssl.so)
+#    endif()
+#endif()
+
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
+
+############ Envitia ############
+# set MapLink definitions
+include ("../../maplinkqtdefs.cmake")
+if(NOT WIN32)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
+endif()
+# setup the default build type.
+if( NOT CMAKE_BUILD_TYPE )
+  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE )
+endif()
+
+# set include directories and link libraries
+if(WIN32)
+	#message("Windows build")
+	# include directories
+	include_directories(${MAPLINK_INCLUDE_DIR})
+	# link directories
+	link_directories(${MAPLINK_LIB_DIR})
+	# link libraries
+	set(link_libs_qpixmapexample MapLink${MLS})
+	# add definitions
+	add_definitions(-DTTLDLL -DWINNT -D_CRT_SECURE_NO_WARNINGS)
+elseif (UNIX)
+	#message("Unix build")
+	# include directories
+	include_directories(${MAPLINK_INCLUDE_DIR})
+	# link directories
+	find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core X11Extras REQUIRED)
+	link_directories(${MAPLINK_LIB_DIR})
+	# link libraries
+	set(link_libs_qpixmapexample MapLink Qt${QT_VERSION_MAJOR}::X11Extras)
+endif()
+	
+# set source files
+set(sources 
+    main.cpp
+	)
+	
+# add source files to the executable
+if(ANDROID)
+  add_library(${APP_NAME_qpixmapexample} SHARED
+    ${sources}
+  )
+else()
+  add_executable(${APP_NAME_qpixmapexample}
+    ${sources}
+  )
+endif()
+
+# link app to link libraries
+target_link_libraries(${APP_NAME_qpixmapexample} PRIVATE Qt${QT_VERSION_MAJOR}::Widgets ${link_libs_qpixmapexample})
+
+# install
+install(TARGETS ${APP_NAME_qpixmapexample} COMPONENT runtime DESTINATION ${MAPLINK_ROOT_DIR}/bin64)

--- a/Qt/qpixmapexample/README.md
+++ b/Qt/qpixmapexample/README.md
@@ -1,0 +1,54 @@
+
+
+# Envitia MapLink QPixmap Sample
+[![API reference](https://img.shields.io/badge/MapLink%20Pro%20API%20Documentation-84bd00)](https://www.envitia.com/technologies/products/maplink-pro/userguide/index.html) [![Blog](https://img.shields.io/badge/Envitia%20Blog-1F2A44)](https://www.envitia.com/category/the-envitia-blog/) 
+
+## Introduction
+
+This sample code demonstrates how to draw MapLink maps into off-screen QPixmaps before drawing the pixmap to screen.
+
+## Try Envitia MapLink Pro
+[Get an evaluation copy of MapLink Pro](mailto:info@envitia.com?subject=I%20want%20to%20evaluate%20MapLink%20Pro%20please)
+
+## Resources
+- [Envitia MapLink Pro API Documentation](https://www.envitia.com/technologies/products/maplink-pro/userguide/index.html)
+- [Qt](https://www.qt.io/)
+
+## Build Instructions
+Requires Qmake.
+### Windows
+
+ 1. Update your local copy of [maplinkqtdefs.pri](../maplinkqtdefs.pri ) to point at your installed MapLink root folder (e.g. MAPLINK_ROOT_DIR="C:/my_installs/Envitia/MapLink Pro/11.0").
+ 2. Launch a Visual Studio x64 Native Tools Command Line.
+ 3. Navigate to the folder containing this readme.
+ 4. `qmake`
+
+### Linux
+
+ 1. In the command line, navigate to your MapLink distribution directory.
+ 2. `. mapl_init.bash`
+ 3. Navigate to the folder containing this readme.
+ 4. `qmake`
+ 5. `make`
+
+## Contributing
+Everyone is welcome to contribute to this repository.
+
+## Licensing
+Copyright 2022 Envitia Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [LICENSE](../../LICENSE) file.
+##
+[![Envitia MapLink Pro](https://user-images.githubusercontent.com/60386764/159908069-b33f1ba7-6ad9-45d0-a872-dfd38dc40c91.png)](http://maplinkpro.com/)

--- a/Qt/qpixmapexample/main.cpp
+++ b/Qt/qpixmapexample/main.cpp
@@ -1,3 +1,16 @@
+/****************************************************************************
+Copyright (c) 2008-2022 by Envitia Group PLC.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+****************************************************************************/
+
 #include <QApplication>
 #include <QGraphicsObject>
 #include <QGraphicsView>

--- a/Qt/qpixmapexample/main.cpp
+++ b/Qt/qpixmapexample/main.cpp
@@ -1,0 +1,281 @@
+#include <QApplication>
+#include <QGraphicsObject>
+#include <QGraphicsView>
+#include <QPainter>
+#include <QPaintEvent>
+#include <qbitmap.h>
+#include <windows.h>
+
+#include <MapLink.h>
+
+#include <memory>
+
+PBITMAPINFO CreateBitmapInfoStruct(HBITMAP hBmp)
+{
+  BITMAP bmp;
+  PBITMAPINFO pbmi;
+  WORD    cClrBits;
+
+  // Retrieve the bitmap color format, width, and height.  
+  if (!GetObject(hBmp, sizeof(BITMAP), (LPSTR)&bmp))
+    return nullptr;
+
+  // Convert the color format to a count of bits.  
+  cClrBits = (WORD)(bmp.bmPlanes * bmp.bmBitsPixel);
+  if (cClrBits == 1)
+    cClrBits = 1;
+  else if (cClrBits <= 4)
+    cClrBits = 4;
+  else if (cClrBits <= 8)
+    cClrBits = 8;
+  else if (cClrBits <= 16)
+    cClrBits = 16;
+  else if (cClrBits <= 24)
+    cClrBits = 24;
+  else cClrBits = 32;
+
+  // Allocate memory for the BITMAPINFO structure. (This structure  
+  // contains a BITMAPINFOHEADER structure and an array of RGBQUAD  
+  // data structures.)  
+
+  if (cClrBits < 24)
+  {
+    pbmi = (PBITMAPINFO)LocalAlloc(LPTR, sizeof(BITMAPINFOHEADER) + sizeof(RGBQUAD) * (1ULL << cClrBits));
+  }
+  // There is no RGBQUAD array for these formats: 24-bit-per-pixel or 32-bit-per-pixel 
+  else
+  {
+    pbmi = (PBITMAPINFO)LocalAlloc(LPTR, sizeof(BITMAPINFOHEADER));
+  }
+
+  // Initialize the fields in the BITMAPINFO structure.  
+
+  pbmi->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+  pbmi->bmiHeader.biWidth = bmp.bmWidth;
+  pbmi->bmiHeader.biHeight = bmp.bmHeight;
+  pbmi->bmiHeader.biPlanes = bmp.bmPlanes;
+  pbmi->bmiHeader.biBitCount = bmp.bmBitsPixel;
+  if (cClrBits < 24)
+    pbmi->bmiHeader.biClrUsed = (1 << cClrBits);
+
+  // If the bitmap is not compressed, set the BI_RGB flag.  
+  pbmi->bmiHeader.biCompression = BI_RGB;
+
+  // Compute the number of bytes in the array of color  
+  // indices and store the result in biSizeImage.  
+  // The width must be DWORD aligned unless the bitmap is RLE 
+  // compressed. 
+  pbmi->bmiHeader.biSizeImage = ((pbmi->bmiHeader.biWidth * cClrBits + 31) & ~31) / 8 * pbmi->bmiHeader.biHeight;
+  // Set biClrImportant to 0, indicating that all of the  
+  // device colors are important.  
+  pbmi->bmiHeader.biClrImportant = 0;
+  return pbmi;
+}
+
+
+class MyGraphicsObject : public QGraphicsObject
+{
+public:
+  MyGraphicsObject(std::string mapPath, std::vector<std::string> overlayImagePaths) 
+  {
+    mapPixmap.reset(new QPixmap());
+
+    for (auto overlayPath : overlayImagePaths)
+    {
+      overlayImagePixmaps.push_back(new QPixmap(overlayPath.c_str()));
+    }
+
+    screenDc = CreateDC(L"DISPLAY", nullptr, nullptr, nullptr);
+    displayDc = CreateCompatibleDC(screenDc);
+    
+    m_drawingSurface.reset(new TSLNTSurface(displayDc, true));
+    m_dataLayer.reset(new TSLMapDataLayer());
+
+    QRect cr = boundingRect().toRect();
+    bool mapLoaded = m_drawingSurface->wndResize(0, 0, cr.width(), cr.height(), false);
+    mapLoaded = m_drawingSurface->reset();
+
+    mapLoaded = m_dataLayer->loadData(mapPath.c_str());
+    mapLoaded = m_drawingSurface->addDataLayer(m_dataLayer.get(), "map");
+
+    std::pair<double, double> bottomLeft = { 0,0 };
+    std::pair<double, double> topRight = { 0,0 };
+    m_dataLayer->getUUExtent(&bottomLeft.first, &bottomLeft.second, &topRight.first, &topRight.second, m_drawingSurface.get());
+    m_drawingSurface->resize(bottomLeft.first, bottomLeft.second, topRight.first, topRight.second, true, true);
+  }
+
+  ~MyGraphicsObject()
+  {
+    DeleteObject(displayDc);
+    DeleteDC(screenDc);
+
+    for (auto* overlay : overlayImagePixmaps)
+    {
+      delete overlay;
+    }
+  }
+
+  QRectF boundingRect() const {
+    const QRectF targetRect = { -299, -99, 600, 200 };
+    return targetRect;
+  }
+
+  void paint(QPainter* painter, const QStyleOptionGraphicsItem*, QWidget*)
+  {
+    QRectF widgetRect = boundingRect();
+    QRect cr = boundingRect().toRect();
+
+    // Draw the pixmaps to screen
+    DrawToPixmap(m_drawingSurface.get(), mapPixmap.get(), cr);
+    painter->drawPixmap(cr, *mapPixmap);
+    for (auto& pixmap : overlayImagePixmaps)
+    {
+      painter->drawPixmap(0, 0, 30, 30, *pixmap);
+    }
+
+  }
+
+  bool DrawToPixmap(TSLNTSurface* drawingSurface, QPixmap* pixmap, QRect& cr)
+  {
+	// Create a bitmap, Windows style
+    HBITMAP hBitmap = CreateCompatibleBitmap(screenDc, cr.width(), cr.height());
+    SelectObject(displayDc, hBitmap);
+
+    // Size the drawing surface to the bitmaps dimensions
+    drawingSurface->wndResize(0, 0, cr.width(), cr.height(), true, TSLResizeActionMaintainCentre);
+	
+	// Get the visible extent of the map in user units
+    std::pair<double, double> bottomLeft = { 0,0 };
+    std::pair<double, double> topRight = { 0,0 };
+    drawingSurface->getUUExtent(&bottomLeft.first, &bottomLeft.second, &topRight.first, &topRight.second);
+
+    //Tell the drawing surface to draw to the bitmap.
+    bool result = drawingSurface->drawToHDC((TSLDeviceContext)displayDc, bottomLeft.first, bottomLeft.second, topRight.first, topRight.second, false);
+
+    // Setup stuff we need to get the bitmap bits (Windows style)
+    PBITMAPINFOHEADER pbih;  
+    LPBYTE lpBits;
+    PBITMAPINFO pbi = CreateBitmapInfoStruct(hBitmap);
+    pbih = (PBITMAPINFOHEADER)pbi;
+    lpBits = (LPBYTE)GlobalAlloc(GMEM_FIXED, pbih->biSizeImage);
+	// Windows bitmaps are top-down, negating biHeight instructs Windows to read the lines in reverse
+    pbi->bmiHeader.biHeight = -pbi->bmiHeader.biHeight;
+
+    // Get the bitmap bits.
+    GetDIBits(displayDc, hBitmap, 0, (WORD)cr.height(), lpBits, pbi, DIB_RGB_COLORS);
+
+    // We now have the bitmap the right way up and in RGB 32 format. Load into a QImage...
+    QImage image(lpBits, cr.width(), cr.height(), QImage::Format_RGB32);
+	// ... which we then load into the pixmap.
+    *pixmap = QPixmap::fromImage(image);
+
+    // Free memory.  
+    GlobalFree((HGLOBAL)lpBits);
+    LocalFree(pbi);
+
+    return result;
+  }
+
+  std::unique_ptr<QPixmap> mapPixmap;
+  std::vector<QPixmap*> overlayImagePixmaps;
+
+  std::unique_ptr<TSLNTSurface> m_drawingSurface;
+  std::unique_ptr<TSLDataLayer, TSLDestroyPointer<TSLDataLayer>> m_dataLayer;
+
+  HDC screenDc = nullptr;
+  HDC displayDc = nullptr;
+};
+
+class View : public QGraphicsView {
+public:
+  View(QWidget* parent = 0) :
+    QGraphicsView(parent)
+  {
+    // This brings the original paint engine alive.
+    QGraphicsView::paintEngine();
+
+    setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
+    setAttribute(Qt::WA_NativeWindow);
+    setAttribute(Qt::WA_PaintOnScreen);
+    setRenderHint(QPainter::Antialiasing);
+  }
+
+  QPaintEngine* paintEngine() const Q_DECL_OVERRIDE { return 0; }
+
+  void create()
+  {
+    if (!created)
+    {
+      TSLErrorStack::clear();
+      TSLDrawingSurface::loadStandardConfig();
+      TSLDrawingSurface::setupSymbols("tslsymbolsAPP6A.dat");
+      TSLCoordinateSystem::loadCoordinateSystems();
+
+      created = true;
+    }
+
+  }
+
+  bool event(QEvent* event) Q_DECL_OVERRIDE {
+
+    switch (event->type())
+    {
+    case QEvent::Create:
+      create();
+      break;
+
+    case QEvent::Resize:
+      if (!created)
+      {
+        create();
+      }
+
+      break;
+
+    case QEvent::Paint:
+    {
+      break;
+    }
+    case QEvent::UpdateRequest:
+    {
+      break;
+    }
+    }
+
+    return QGraphicsView::event(event);
+  }
+
+  void resizeEvent(QResizeEvent* event) {
+    fitInView(0,0,event->size().width(), event->size().height(), Qt::KeepAspectRatio);
+  }
+
+private:
+  bool created = false;
+};
+
+
+int main(int argc, char* argv[])
+{
+  enum Args
+  {
+    Arg_map = 1, // First argument is the path to a MapLink Map
+    Arg_overlayImagesStart // Can then have as many paths to images as you like, they will be loaded into a pixmap and drawn over the map.
+  };
+
+  std::string mapPath = (argc >= Arg_map ? argv[Arg_map] : "");
+  std::vector<std::string> imagePaths;
+  for (int arg = Arg_overlayImagesStart; arg < argc; ++arg)
+  {
+    imagePaths.push_back(argv[arg]);
+  }
+
+  QApplication a(argc, argv);
+  QGraphicsScene s;
+  MyGraphicsObject* obj = new MyGraphicsObject(mapPath, imagePaths);
+  s.addItem(obj);
+  View view;
+  view.setScene(&s);
+  view.show();
+
+  return a.exec();
+}

--- a/Qt/qpixmapexample/qpixmapexample.pro
+++ b/Qt/qpixmapexample/qpixmapexample.pro
@@ -1,0 +1,62 @@
+#****************************************************************************
+#                Copyright (c) 2022 by Envitia Group PLC.
+#****************************************************************************
+
+# Only release configurations are generated - on Windows debug builds can only be used if the same version
+# of Visual Studio that MapLink was built with is used.
+# On windows only release or debug should be added to CONFIG. Using debug_and_release will generate 
+# an invalid project due to the way conditions are evaluated by qmake.
+CONFIG -=  debug_and_release release debug
+CONFIG += qt thread release
+
+# The CONFIG variable must be setup before including maplinkqtdefs.pri
+dev {
+  include(../../maplinkqtdefs.pri)
+} else {
+  include(../maplinkqtdefs.pri)
+}
+
+TARGET = maplinkqpixmapexample
+
+QT += widgets
+
+win32 {
+  message("Windows build")
+  CONFIG += windows
+  INCLUDEPATH += $$quote($${MAPLINK_INCLUDE_DIR})
+  
+  LIBS += $$quote($${MAPLINK_LIB_DIR}/MapLink$${MLS})
+    
+  # Use the appropriate libraries depending on whether this is a 32 or 64bit build of Qt
+  contains( QMAKE_HOST.arch, x86_64 ) {
+    message( "64bit Qt build detected" )
+    QMAKE_LFLAGS *= /MACHINE:X64
+  } else {
+    message( "32bit Qt build detected" )
+    QMAKE_LFLAGS *= /MACHINE:X86
+  }
+  
+  DEFINES += TTLDLL WINNT _CRT_SECURE_NO_WARNINGS
+  CharacterSet = 1
+   
+  TEMPLATE = vcapp
+  DESTDIR = $$PWD/$$QMAKE_HOST.arch
+  OBJECTS_DIR = $$PWD/$$QMAKE_HOST.arch
+}
+
+unix {
+  message("Unix build")
+  greaterThan(QT_MAJOR_VERSION, 4): QT += x11extras
+  INCLUDEPATH += $${MAPLINK_INCLUDE_DIR}
+  
+  LIBS += -L$$MAPLINK_LIB_DIR
+  
+  LIBS += -lMapLink
+  TEMPLATE = app
+} 
+
+# Common Input
+FORMS = 
+HEADERS = 
+SOURCES = main.cpp
+


### PR DESCRIPTION
Added an example project to demonstrate how to draw a MapLink map to a QPixmap, without the use of the deprecated QPixmap.handle() method.